### PR TITLE
Fix landing detection globals

### DIFF
--- a/flight_code.ino
+++ b/flight_code.ino
@@ -377,9 +377,13 @@ void loop() {
           logSensorData();
         }
         
-        // Landing detection: if altitude (y) and relative altitude (relAlt) change by less than LANDING_ALT_CHANGE_THRESHOLD for LANDING_TIME_THRESHOLD ms.
-        static float prevAltitude = y;
-        static unsigned long landingTimerStart = millis();
+        // Landing detection: if altitude (y) and relative altitude (relAlt) change by less than
+        // LANDING_ALT_CHANGE_THRESHOLD for LANDING_TIME_THRESHOLD ms. Use global variables so the
+        // state persists outside this loop.
+        if (landingTimerStart == 0) {
+          landingTimerStart = millis();
+          prevAltitude = y;
+        }
         if ((fabs(y - prevAltitude) < LANDING_ALT_CHANGE_THRESHOLD) &&
             (fabs(relAlt - prevAltitude) < LANDING_ALT_CHANGE_THRESHOLD)) {
           if (millis() - landingTimerStart >= LANDING_TIME_THRESHOLD) {


### PR DESCRIPTION
## Summary
- remove local statics from landing detection
- use global variables so timer and altitude persist

## Testing
- `apt-get update`
- `apt-get install -y arduino-cli` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860040f938483299f8c6d0d9b9a9770