### PR TITLE
Fix duplicate EKF gain definition

### DIFF
--- a/flight_code.ino
+++ b/flight_code.ino
@@ -101,7 +101,6 @@ float altitudeBias      = 0.0f;
 float baselineAltitude  = 0.0f;
 
 // EKF (state, cov, etc.) live in ekf_sensor_fusion.cpp-style section
-Eigen::MatrixXf lastKalmanGain;
 
 // System files
 File rawDataFile, filteredDataFile, systemLogFile;


### PR DESCRIPTION
## Summary
- remove redundant `lastKalmanGain` variable from early declarations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68646637f3808329b582774f29d0a7b1